### PR TITLE
feat(datadog): env flag to disable datadog client by default

### DIFF
--- a/monitoring.go
+++ b/monitoring.go
@@ -9,3 +9,4 @@ type Monitor interface {
 	Event(title, text string) error
 	Gauge(name string, value float64, tags []string, rate float64) error
 }
+


### PR DESCRIPTION
This PR is mostly for local development.  As you develop a local application that integrates datadog metrics, you'll want to disable the client by default because it sends real data to real agents.  In this case we return a mock monitor client that does nothing.

If you actually want to enable datadog you have to pass:  DATADOG_ENABLED=true.  This will require changing any k8s deployment that currently uses this code.