### PR TITLE
feat(log): add standard log utils

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,26 +2,88 @@
 
 
 [[projects]]
+  digest = "1:e64fddc819e2abc68792a743dd857c379449a56f2b9eaf030c03fb0ec19de884"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
+  pruneopts = ""
   revision = "e67964b4021ad3a334e748e8811eb3cd6becbc6e"
   version = "2.1.0"
 
 [[projects]]
+  digest = "1:5247b135b5492aa232a731acdcb52b08f32b874cb398f21ab460396eadbe866b"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:05334858a0cfb538622a066e065287f63f42bee26a7fda93a789674225057201"
+  name = "github.com/hashicorp/go-cleanhttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
+  version = "v0.5.0"
+
+[[projects]]
+  digest = "1:776139dc18d63ef223ffaca5d8e9a3057174890f84393d3c881e934100b66dbc"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "73489d0a1476f0c9e6fb03f9c39241523a496dfd"
+  version = "v0.5.2"
+
+[[projects]]
+  digest = "1:6a874e3ddfb9db2b42bd8c85b6875407c702fa868eed20634ff489bc896ccfd3"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:a5484d4fa43127138ae6e7b2299a6a52ae006c7f803d98d717f60abf3e97192e"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
   version = "v1.2"
+
+[[projects]]
+  digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:cbc1ebc01ec2ceb2c3cc7b9e33357dbc3eff173335f02d9f01603f14102602a7"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  pruneopts = ""
+  revision = "b8fe1690c61389d7d2a8074a507d1d40c5d30448"
+
+[[projects]]
+  branch = "master"
+  digest = "1:71d52943b1ff6a49989bc0eb674aeb46c159845beffd20470a1ee68d8e985532"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
+  revision = "aca44879d5644da7c5b8ec6a1115e9b6ea6c40d9"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ff0ffb7db872106a88911d634722bf9c1622365469a9bf117999ed6aeea32e7"
+  input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
+    "github.com/hashicorp/go-retryablehttp",
+    "github.com/pborman/uuid",
+    "github.com/sirupsen/logrus",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/log/formatters/formatters.go
+++ b/log/formatters/formatters.go
@@ -1,0 +1,52 @@
+package formatters
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+const (
+	HTTP_FORMAT_SEPERATOR         = "--"
+	HTTP_FORMAT_VALIDATION_ERRROR = "NewHttpLogFormatter called without %s field"
+)
+
+type HttpLogFormatter struct {
+	Hostname   string
+	CustomerID string
+	Version    string
+}
+
+
+func NewHttpLogFormatter(hostname, customerID, version string) (*HttpLogFormatter, error) {
+	fields := map[string]string{
+		"hostname": hostname,
+		"customerID": customerID,
+		"version": version,
+	}
+	for attr, val := range fields {
+		if val == "" {
+			return nil, fmt.Errorf(HTTP_FORMAT_VALIDATION_ERRROR, attr)
+		}
+	}
+
+	return &HttpLogFormatter{
+		Hostname:   hostname,
+		CustomerID: customerID,
+		Version:    version,
+	}, nil
+}
+
+func (hlf *HttpLogFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	parts := []string{
+		hlf.Hostname,
+		hlf.CustomerID,
+		hlf.Version,
+		"main",
+		strings.ToUpper(e.Level.String()),
+		"golang",
+		HTTP_FORMAT_SEPERATOR,
+		strings.TrimSpace(e.Message),
+	}
+	return []byte(strings.Join(parts, " ")), nil
+}

--- a/log/formatters/formatters_test.go
+++ b/log/formatters/formatters_test.go
@@ -1,0 +1,77 @@
+package formatters
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"testing"
+)
+
+type testInput struct {
+	hostname   string
+	customerID string
+	version    string
+}
+
+func TestNewHttpLogFormatter(t *testing.T) {
+	cases := map[string]struct {
+		input         testInput
+		expectedError error
+	}{
+		"everything supplied, no error": {
+			input:         testInput{hostname: "t", customerID: "t", version: "t"},
+			expectedError: nil,
+		},
+		"missing argument, error": {
+			input:         testInput{hostname: "t", customerID: "t"},
+			expectedError: fmt.Errorf(HTTP_FORMAT_VALIDATION_ERRROR, "version"),
+		},
+	}
+
+	for testName, c := range cases {
+		t.Run(testName, func(t *testing.T) {
+			_, err := NewHttpLogFormatter(c.input.hostname, c.input.customerID, c.input.version)
+			if err == nil && c.expectedError == nil {
+				return
+			}
+
+			if err != nil && c.expectedError == nil {
+				t.Fatalf("got an error when we didn't expect one %s", err.Error())
+			}
+
+			if err.Error() != c.expectedError.Error() {
+				t.Fatalf("go unexpected error message. expected %s\ngot %s", c.expectedError.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestHttpLogFormatter_Format(t *testing.T) {
+	cases := map[string]struct {
+		formatterInput testInput
+		entry          *logrus.Entry
+		expected       string
+	}{
+		"message is in correct format": {
+			formatterInput: testInput{
+				hostname:   "test1",
+				customerID: "test2",
+				version:    "test3",
+			},
+			entry: &logrus.Entry{
+				Message: "hello from the test",
+				Level:   logrus.InfoLevel,
+			},
+			expected: "test1 test2 test3 main INFO golang -- hello from the test",
+		},
+	}
+
+	for testName, c := range cases {
+		t.Run(testName, func(t *testing.T) {
+			f, _ := NewHttpLogFormatter(c.formatterInput.hostname, c.formatterInput.customerID, c.formatterInput.version)
+			out, _ := f.Format(c.entry)
+			if string(out) != c.expected {
+				t.Fatalf("message formatted improperly. expected %s\ngot%s", c.expected, string(out))
+			}
+		})
+	}
+}

--- a/log/hooks/hooks.go
+++ b/log/hooks/hooks.go
@@ -1,0 +1,30 @@
+package hooks
+
+import (
+	"bytes"
+	"github.com/sirupsen/logrus"
+	http "github.com/hashicorp/go-retryablehttp"
+)
+
+const HTTP_DEBUG_CONTENT_TYPE = "application/text"
+
+type HttpDebugHook struct {
+	Endpoint  string
+	LogLevels []logrus.Level
+	Formatter logrus.Formatter
+}
+
+func (hdk *HttpDebugHook) Levels() []logrus.Level {
+	return hdk.LogLevels
+}
+
+func (hdk *HttpDebugHook) Fire(e *logrus.Entry) error {
+	toSend, err := hdk.Formatter.Format(e)
+	if err != nil {
+		return err
+	}
+	if _, err := http.Post(hdk.Endpoint, HTTP_DEBUG_CONTENT_TYPE, bytes.NewReader(toSend)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/log/hooks/hooks_test.go
+++ b/log/hooks/hooks_test.go
@@ -1,0 +1,58 @@
+package hooks
+
+import (
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func serverMock(calls *int) (*httptest.Server, func()) {
+	r := http.NewServeMux()
+	r.HandleFunc("/v1/logs", func(w http.ResponseWriter, r *http.Request) {
+		*calls++
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(r)
+
+	return ts, func() {
+		ts.Close()
+	}
+}
+
+type mockFormatter struct{}
+
+func (mf mockFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	return nil, nil
+}
+
+func TestHttpDebugHook_Fire(t *testing.T) {
+	cases := map[string]struct {
+		entry         *logrus.Entry
+		expectedError error
+	}{
+		"posts to server": {
+			entry: &logrus.Entry{},
+		},
+	}
+
+	for testName, c := range cases {
+		t.Run(testName, func(t *testing.T) {
+			var calls int
+			svr, closeFunc := serverMock(&calls)
+			defer closeFunc()
+			hook := HttpDebugHook{
+				Endpoint:  svr.URL + "/v1/logs",
+				Formatter: mockFormatter{},
+			}
+
+			err := hook.Fire(c.entry)
+			if err != nil && c.expectedError == nil {
+				t.Fatalf("got an error when we didn't expect one %s", err.Error())
+			}
+			if calls != 1 {
+				t.Fatalf("failed to actually call the server")
+			}
+		})
+	}
+}


### PR DESCRIPTION
adds standard logging utilities for logrus. these can use used throughout out go projects for enabling log forwarding to debug.